### PR TITLE
feat: Added hover effect on back button in login and signup page

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,8 +15,10 @@
 .back-arrow {
   font-size: 2em;
   transition: all .2s ease-out;
+  box-shadow: 2px 2px 1px 2px;
 }
 
 .back-arrow:hover {
   transform: translate(0px, 0px) scale(1.3);
+  box-shadow: 4px 4px 15px 1px;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,12 @@
   z-index: -10;
   background-size: cover;
 }
+
+.back-arrow {
+  font-size: 2em;
+  transition: all .2s ease-out;
+}
+
+.back-arrow:hover {
+  transform: translate(0px, 0px) scale(1.3);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -13,12 +13,9 @@
 }
 
 .back-arrow {
-  font-size: 2em;
-  transition: all .2s ease-out;
-  box-shadow: 2px 2px 1px 2px;
+  background-color: #DBE2EF;
 }
 
 .back-arrow:hover {
-  transform: translate(0px, 0px) scale(1.3);
-  box-shadow: 4px 4px 15px 1px;
+  background-color: white;
 }

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -9,7 +9,7 @@ import logo from "../../assets/logos/icon-transparent.svg";
 import {
 	AiOutlineArrowLeft,
 	AiFillEye,
-	AiFillEyeInvisible,
+	AiFillEyeInvisible
 } from "react-icons/ai";
 import { ILoginPayload, loginHandler } from "../../actions/auth.actions";
 import useUpdateObjectState from "../../hooks/useUpdateObjectState";
@@ -27,7 +27,7 @@ const Login: FC = () => {
 	 */
 	const [formData, setFormData] = useState<ILoginPayload>({
 		email: "",
-		password: "",
+		password: ""
 	});
 
 	/**
@@ -44,7 +44,7 @@ const Login: FC = () => {
 	 * @author KanLSK
 	 */
 	const passwordVisibility = () => {
-		setShowPassword((prev) => !prev);
+		setShowPassword(prev => !prev);
 	};
 
 	/**
@@ -67,10 +67,12 @@ const Login: FC = () => {
 
 	return (
 		<div className="absolute top-0 left-0 grid h-screen w-screen place-items-center bg-white font-poppins ">
-			<div className="relative flex h-auto w-[90vw] max-w-6xl flex-col items-center justify-center gap-4 bg-[#DBE2EF] py-10 md:h-[60vh] md:w-[70vw] md:flex-row md:justify-around">
+			<div className="rounded relative flex h-auto w-[90vw] max-w-6xl flex-col items-center justify-center gap-4 bg-[#DBE2EF] py-10 md:h-[60vh] md:w-[70vw] md:flex-row md:justify-around">
 				{/*icon for redirect to home */}
 				<Link to="/" className="absolute top-2 left-2">
-					<AiOutlineArrowLeft className="text-xl" />
+					<div className="back-arrow rounded bg-primary py-1 px-2 text-white">
+						<AiOutlineArrowLeft className="text-xl" />
+					</div>
 				</Link>
 				{/*logo*/}
 				<div className="md:hidden w-fit items-center gap-1 flex">
@@ -82,7 +84,7 @@ const Login: FC = () => {
 					<img src={vector} alt="vector" />
 				</div>
 				{/*separate line*/}
-				<div className="h-[1px] w-[95%] rounded-full border-2 border-[#3f71af60] bg-[#6398da60] md:h-[30vh] md:w-[0px]"></div>
+				<div className="h-[1px] w-[95%] rounded-full border-2 border-[#3f71af60] bg-[#6398da60] md:h-[30vh] md:w-[0px]" />
 				{/*form section */}
 				<form
 					onSubmit={submitHandler}
@@ -102,9 +104,8 @@ const Login: FC = () => {
 							type="email"
 							id="email"
 							value={formData.email}
-							onChange={(e) =>
-								updateFormData("email", e.target.value)
-							}
+							onChange={e =>
+								updateFormData("email", e.target.value)}
 							className="rounded-md px-2 py-1 text-[12px] placeholder-[#3f72af]"
 							placeholder="example@multiemail.us"
 						/>
@@ -117,23 +118,20 @@ const Login: FC = () => {
 							type={showPassword ? "text" : "password"}
 							id="password"
 							value={formData.password}
-							onChange={(e) =>
-								updateFormData("password", e.target.value)
-							}
+							onChange={e =>
+								updateFormData("password", e.target.value)}
 							className="rounded-md px-2 py-1 text-[12px] placeholder-[#3f72af]"
 							placeholder="password"
 						/>
-						{showPassword ? (
-							<AiFillEyeInvisible
-								className="absolute right-2 top-[60%]"
-								onClick={passwordVisibility}
-							/>
-						) : (
-							<AiFillEye
-								className="absolute right-2 top-[60%]"
-								onClick={passwordVisibility}
-							/>
-						)}
+						{showPassword
+							? <AiFillEyeInvisible
+									className="absolute right-2 top-[60%]"
+									onClick={passwordVisibility}
+								/>
+							: <AiFillEye
+									className="absolute right-2 top-[60%]"
+									onClick={passwordVisibility}
+								/>}
 					</div>
 					<button
 						type="submit"

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -70,7 +70,7 @@ const Login: FC = () => {
 			<div className="rounded relative flex h-auto w-[90vw] max-w-6xl flex-col items-center justify-center gap-4 bg-[#DBE2EF] py-10 md:h-[60vh] md:w-[70vw] md:flex-row md:justify-around">
 				{/*icon for redirect to home */}
 				<Link to="/" className="absolute top-2 left-2">
-					<div className="back-arrow rounded bg-primary py-1 px-2 text-white">
+					<div className="back-arrow rounded py-1 px-2">
 						<AiOutlineArrowLeft className="text-xl" />
 					</div>
 				</Link>

--- a/src/pages/signup/Signup.tsx
+++ b/src/pages/signup/Signup.tsx
@@ -10,7 +10,7 @@ import logo from "../../assets/logos/icon-transparent.svg";
 import {
 	AiOutlineArrowLeft,
 	AiFillEye,
-	AiFillEyeInvisible,
+	AiFillEyeInvisible
 } from "react-icons/ai";
 /**
  * Signup page
@@ -30,13 +30,14 @@ const Signup: FC = () => {
 		username: "",
 		email: "",
 		password: "",
-		cpassword: "",
+		cpassword: ""
 	});
 
 	const [error, setError] = useState<string>("");
 	const [showPassword, setShowPassword] = useState<boolean>(false);
-	const [showConfirmPassword, setShowConfirmPassword] =
-		useState<boolean>(false);
+	const [showConfirmPassword, setShowConfirmPassword] = useState<boolean>(
+		false
+	);
 
 	const updateFormData = useUpdateObjectState<ISignupPayload>(setFormData);
 
@@ -60,12 +61,12 @@ const Signup: FC = () => {
 
 	//show password in input field
 	const passwordVisibility = () => {
-		setShowPassword((prev) => !prev);
+		setShowPassword(prev => !prev);
 	};
 
 	//show confirm password in input field
 	const confirmPasswordVisibility = () => {
-		setShowConfirmPassword((prev) => !prev);
+		setShowConfirmPassword(prev => !prev);
 	};
 
 	/*
@@ -93,10 +94,12 @@ const Signup: FC = () => {
 	 */
 	return (
 		<div className="absolute top-0 left-0 grid h-screen w-screen place-items-center bg-white font-poppins">
-			<div className="relative flex h-auto w-[90vw] max-w-6xl flex-col items-center justify-center gap-4 bg-[#DBE2EF] py-10 md:h-[60vh] md:w-[70vw] md:flex-row md:justify-around">
+			<div className="rounded relative flex h-auto w-[90vw] max-w-6xl flex-col items-center justify-center gap-4 bg-[#DBE2EF] py-10 md:h-[60vh] md:w-[70vw] md:flex-row md:justify-around">
 				{/*icon for redirect to home */}
 				<Link to="/" className="absolute top-2 left-2">
-					<AiOutlineArrowLeft className="text-xl" />
+					<div className="back-arrow rounded bg-primary py-1 px-2 text-white">
+						<AiOutlineArrowLeft className="text-xl" />
+					</div>
 				</Link>
 				{/*logo*/}
 				<div className="flex w-fit items-center gap-1 md:hidden">
@@ -108,7 +111,7 @@ const Signup: FC = () => {
 					<img src={vector} alt="vector" />
 				</div>
 				{/*separate line*/}
-				<div className="h-[1px] w-[95%] rounded-full border-2 border-[#3f71af60] bg-[#6398da60] md:h-[30vh] md:w-[0px]"></div>
+				<div className="h-[1px] w-[95%] rounded-full border-2 border-[#3f71af60] bg-[#6398da60] md:h-[30vh] md:w-[0px]" />
 				<form
 					className="flex w-[90%] flex-col items-center gap-3 md:w-[40%]"
 					onSubmit={submitHandler}
@@ -129,9 +132,8 @@ const Signup: FC = () => {
 							placeholder="multiemail"
 							className="rounded-md px-2 py-1 text-[12px] placeholder-[#3f72af]"
 							value={formData.username}
-							onChange={(e) =>
-								updateFormData("username", e.target.value)
-							}
+							onChange={e =>
+								updateFormData("username", e.target.value)}
 						/>
 					</div>
 					<div className="flex w-[90%] flex-col gap-2 text-[#3F72AF]">
@@ -144,9 +146,8 @@ const Signup: FC = () => {
 							placeholder="info@multiemail.us"
 							className="rounded-md px-2 py-1 text-[12px] placeholder-[#3f72af]"
 							value={formData.email}
-							onChange={(e) =>
-								updateFormData("email", e.target.value)
-							}
+							onChange={e =>
+								updateFormData("email", e.target.value)}
 						/>
 					</div>
 					<div className="relative flex w-[90%] flex-col gap-2 text-[#3F72AF]">
@@ -159,21 +160,18 @@ const Signup: FC = () => {
 							placeholder="strongpassword"
 							className="rounded-md px-2 py-1 text-[12px] placeholder-[#3f72af]"
 							value={formData.password}
-							onChange={(e) =>
-								updateFormData("password", e.target.value)
-							}
+							onChange={e =>
+								updateFormData("password", e.target.value)}
 						/>
-						{showPassword ? (
-							<AiFillEyeInvisible
-								className="absolute right-2 top-[65%] cursor-pointer"
-								onClick={passwordVisibility}
-							/>
-						) : (
-							<AiFillEye
-								className="absolute right-2 top-[65%] cursor-pointer"
-								onClick={passwordVisibility}
-							/>
-						)}
+						{showPassword
+							? <AiFillEyeInvisible
+									className="absolute right-2 top-[65%] cursor-pointer"
+									onClick={passwordVisibility}
+								/>
+							: <AiFillEye
+									className="absolute right-2 top-[65%] cursor-pointer"
+									onClick={passwordVisibility}
+								/>}
 					</div>
 					<div className="relative flex w-[90%] flex-col gap-2 text-[#3F72AF]">
 						<label className="text-[14px]" htmlFor="cpassword">
@@ -185,21 +183,18 @@ const Signup: FC = () => {
 							placeholder="confirm your password"
 							className="rounded-md px-2 py-1 text-[12px] placeholder-[#3f72af]"
 							value={formData.cpassword}
-							onChange={(e) =>
-								updateFormData("cpassword", e.target.value)
-							}
+							onChange={e =>
+								updateFormData("cpassword", e.target.value)}
 						/>
-						{showConfirmPassword ? (
-							<AiFillEyeInvisible
-								className="absolute right-2 top-[65%] cursor-pointer"
-								onClick={confirmPasswordVisibility}
-							/>
-						) : (
-							<AiFillEye
-								className="absolute right-2 top-[65%] cursor-pointer"
-								onClick={confirmPasswordVisibility}
-							/>
-						)}
+						{showConfirmPassword
+							? <AiFillEyeInvisible
+									className="absolute right-2 top-[65%] cursor-pointer"
+									onClick={confirmPasswordVisibility}
+								/>
+							: <AiFillEye
+									className="absolute right-2 top-[65%] cursor-pointer"
+									onClick={confirmPasswordVisibility}
+								/>}
 					</div>
 					<div className="flex items-center gap-2">
 						<input type="checkbox" />

--- a/src/pages/signup/Signup.tsx
+++ b/src/pages/signup/Signup.tsx
@@ -97,7 +97,7 @@ const Signup: FC = () => {
 			<div className="rounded relative flex h-auto w-[90vw] max-w-6xl flex-col items-center justify-center gap-4 bg-[#DBE2EF] py-10 md:h-[60vh] md:w-[70vw] md:flex-row md:justify-around">
 				{/*icon for redirect to home */}
 				<Link to="/" className="absolute top-2 left-2">
-					<div className="back-arrow rounded bg-primary py-1 px-2 text-white">
+					<div className="back-arrow rounded py-1 px-2">
 						<AiOutlineArrowLeft className="text-xl" />
 					</div>
 				</Link>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4999,7 +4999,7 @@ fs.realpath@^1.0.0:
 
 fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.2"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:


### PR DESCRIPTION
<!-- -------------------------- Required section --------------------------- -->

### Description
I have wrapped the back button inside a div to which I have applied the CSS. Used tailwind CSS class names for bg color, border and padding. For the hover effect, I have used a custom class name ```back-arrow``` for which the CSS is defined in index.css. I zoomed the arrow and changed the shadow upon hovering.


### Checklist:

<!-- pull request can be still created if all tasks are not completed  -->

- [x ] This pull request follow our contribution guidelines
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation (postman and swagger)
- [ x] I have written tests for the code
- [ x] I have updated .env.example file for new .env variables

<!-- -------------------------- Optional section --------------------------- -->

### What is current behavior?
#54

Closes #54

### What is new behavior?

[3792ed57-0c2b-44b2-a99a-fcecbfe331de.webm](https://user-images.githubusercontent.com/64556550/194624896-bfc55f2a-e7b2-4706-adfe-c5c0126eef54.webm)

### Breaking Changes?

There are no breaking changes

### Additional information

You can also shift the button left or right using the transform translate.
```
.back-arrow:hover {
  transform: translate(5px, 0px) scale(1.3);
  box-shadow: 4px 4px 15px 1px;
}
```